### PR TITLE
Mac support

### DIFF
--- a/_fastcd
+++ b/_fastcd
@@ -11,7 +11,7 @@ function _fastcd() {
                 -iwholename '*.git*' -o \
                 -iwholename '*.svn*' -o \
                 -iwholename '*.hg*' \) \
-            -printf '%f\n' \
+            -print | xargs -n 1 basename \
         | sort | uniq -u
     ))
 


### PR DESCRIPTION
on mac find has no `-printf` flag, but combination of `-print` and `basename` would work in both os-es